### PR TITLE
to find  resolution of jpeg image

### DIFF
--- a/hepsy/h1.py
+++ b/hepsy/h1.py
@@ -1,0 +1,24 @@
+def jpeg_res(filename):
+   """"This function prints the resolution of the jpeg image file passed into it"""
+
+   # open image for reading in binary mode
+   with open(filename,'rb') as img_file:
+
+       # height of image (in 2 bytes) is at 164th position
+       img_file.seek(163)
+
+       # read the 2 bytes
+       a = img_file.read(2)
+
+       # calculate height
+       height = (a[0] << 8) + a[1]
+
+       # next 2 bytes is width
+       a = img_file.read(2)
+
+       # calculate width
+       width = (a[0] << 8) + a[1]
+
+   print("The resolution of the image is",width,"x",height)
+
+jpeg_res("img1.jpg")


### PR DESCRIPTION
In this program, we opened the image in binary mode. Non-text files must be open in this mode. The height of the image is at 164th position followed by width of the image. Both are 2 bytes long.

Note that this is true only for JPEG File Interchange Format (JFIF) standard. If your image is encode using other standard (like EXIF), the code will not work.

We convert the 2 bytes into a number using bitwise shifting operator <<. Finally, the resolution is displayed.